### PR TITLE
chore(deps): migrate to sypl v2

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,9 +18,9 @@ import (
 	"github.com/thalesfsp/inference/huggingface"
 	"github.com/thalesfsp/inference/ollama"
 	"github.com/thalesfsp/inference/openai"
-	"github.com/thalesfsp/sypl"
-	"github.com/thalesfsp/sypl/level"
-	"github.com/thalesfsp/sypl/processor"
+	"github.com/thalesfsp/sypl/v2"
+	"github.com/thalesfsp/sypl/v2/level"
+	"github.com/thalesfsp/sypl/v2/processor"
 )
 
 // CLI tool configuration flags.

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/thalesfsp/customerror v1.2.7
 	github.com/thalesfsp/inference v0.0.8
 	github.com/thalesfsp/sypl v1.9.18
+	github.com/thalesfsp/sypl/v2 v2.0.0
 )
 
 require (
@@ -34,7 +35,7 @@ require (
 	github.com/elastic/go-windows v1.0.2 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
-	github.com/fatih/color v1.17.0 // indirect
+	github.com/fatih/color v1.18.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.6 // indirect
 	github.com/go-jose/go-jose/v4 v4.0.4 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
@@ -102,7 +103,7 @@ require (
 	golang.org/x/mod v0.21.0 // indirect
 	golang.org/x/net v0.30.0 // indirect
 	golang.org/x/sync v0.8.0 // indirect
-	golang.org/x/sys v0.26.0 // indirect
+	golang.org/x/sys v0.27.0 // indirect
 	golang.org/x/term v0.25.0 // indirect
 	golang.org/x/text v0.19.0 // indirect
 	golang.org/x/time v0.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,8 @@ github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
-github.com/fatih/color v1.17.0 h1:GlRw1BRJxkpqUCBKzKOw098ed57fEsKeNjpTe3cSjK4=
-github.com/fatih/color v1.17.0/go.mod h1:YZ7TlrGPkiz6ku9fK3TLD/pl3CpsiFyu8N92HLgmosI=
+github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
+github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/gabriel-vasile/mimetype v1.4.6 h1:3+PzJTKLkvgjeTbts6msPJt4DixhT4YtFNf1gtGe3zc=
@@ -246,8 +246,6 @@ github.com/thalesfsp/httpclient v1.2.7 h1:y/amR8KpPNff0nR2qP7J6sMFW9BCq/Qiia14ky
 github.com/thalesfsp/httpclient v1.2.7/go.mod h1:+cGuQs0+VR8Vy3mPHeVd9UMZP0PA0tzFmtILMuiSGOg=
 github.com/thalesfsp/httpclient/v2 v2.0.1 h1:Te1ouJo/wPjjlxZEQTBOuCcGiWLJffwaPEzBX+WR/yY=
 github.com/thalesfsp/httpclient/v2 v2.0.1/go.mod h1:txblSCREf17cpPDwwVK8vqaoNZrM+KhEqsU/wpfQYso=
-github.com/thalesfsp/inference v0.0.3 h1:SlR0ZxqnFDdqG569BYdNhosqsdnCk2u2WPphBg27dDk=
-github.com/thalesfsp/inference v0.0.3/go.mod h1:K0N+5cBt3nEMmdhnQM6qICXthzgdZgFYwQ1PW8MbixY=
 github.com/thalesfsp/inference v0.0.8 h1:996qlkd7l1v7QMV0eQ12MzN8KK2nZYPY6Z4JVxiEblA=
 github.com/thalesfsp/inference v0.0.8/go.mod h1:K0N+5cBt3nEMmdhnQM6qICXthzgdZgFYwQ1PW8MbixY=
 github.com/thalesfsp/mole v1.0.2 h1:TaZafQY7xiZ7sDEJuoMP1hlCciOKUjG5H0zSqwaR7D0=
@@ -258,6 +256,8 @@ github.com/thalesfsp/status v1.0.18 h1:omyxzT8rsujxztMyS8G4eyIauU3I4FBMUSRrNpbbT
 github.com/thalesfsp/status v1.0.18/go.mod h1:ZwlaaU4tPETPq/wf3bsS/sVqSQpMUPMK7iTqkSSJqVY=
 github.com/thalesfsp/sypl v1.9.18 h1:TWR7zWRLA9kJECsvNghdWtGPll7+BrHlaV/08xeV8dg=
 github.com/thalesfsp/sypl v1.9.18/go.mod h1:XVdPSJi9P0QptQnWaUUjZ67GpUBI91Q8AQzbUmy9zj4=
+github.com/thalesfsp/sypl/v2 v2.0.0 h1:sG8R5DPKpsbq0pF+jSlEy1XNYIrhTUbfwA1duLmq5/8=
+github.com/thalesfsp/sypl/v2 v2.0.0/go.mod h1:RCM1KBOet35pLWc6VPixSPPa5neyxaGJHGeRT5CEczY=
 github.com/thalesfsp/validation v0.0.3 h1:iXWXZLALIGUKJSxAeDt40kxUyzjeHeHc86f9fP9vin4=
 github.com/thalesfsp/validation v0.0.3/go.mod h1:0jwfQpbuzVJgVSPoiDJ7KCT76CLdMq4R++InC353SZ8=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
@@ -312,8 +312,8 @@ golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.26.0 h1:KHjCJyddX0LoSTb3J+vWpupP9p0oznkqVk/IfjymZbo=
-golang.org/x/sys v0.26.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.27.0 h1:wBqf8DvsY9Y/2P8gAfPDEYNuS30J4lPHJxXSb/nJZ+s=
+golang.org/x/sys v0.27.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.25.0 h1:WtHI/ltw4NvSUig5KARz9h521QvRC8RmF/cuYqifU24=
 golang.org/x/term v0.25.0/go.mod h1:RPyXicDX+6vLxogjjRxjgD2TKtmAO6NZBsBRfrOLu7M=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/internal/errorcatalog/errorcatalog.go
+++ b/internal/errorcatalog/errorcatalog.go
@@ -14,7 +14,7 @@ const (
 	ErrFailedToCallLLM          = "ERR_FAILED_TO_CALL_LLM"           // FailedTo.
 	ErrFailedToChunkDiff        = "ERR_FAILED_TO_CHUNK_DIFF"         // FailedTo.
 	ErrFailedToCreateHTTPClient = "ERR_FAILED_TO_CREATE_HTTP_CLIENT" // FailedTo.
-	ErrFailedToGetTags          = "ERR_FAILED_TO_GET_TAGS"            // FailedTo.
+	ErrFailedToGetTags          = "ERR_FAILED_TO_GET_TAGS"           // FailedTo.
 	ErrFailedToGitDiff          = "ERR_FAILED_TO_GIT_DIFF"           // FailedTo.
 	ErrFailedToGitStats         = "ERR_FAILED_TO_GIT_STATS"          // FailedTo.
 	ErrFailedToInitChunker      = "ERR_FAILED_TO_INIT_CHUNKER"       // FailedTo.

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -20,10 +20,10 @@ func (m *mockProvider) Completion(ctx context.Context, options ...provider.Func)
 	return m.completionFunc(ctx, options...)
 }
 
-func (m *mockProvider) GetClient() any               { return nil }
-func (m *mockProvider) GetLogger() sypl.ISypl         { return sypl.NewDefault("test", level.Info) }
-func (m *mockProvider) GetName() string               { return "mock" }
-func (m *mockProvider) GetType() string               { return "mock" }
+func (m *mockProvider) GetClient() any                          { return nil }
+func (m *mockProvider) GetLogger() sypl.ISypl                   { return sypl.NewDefault("test", level.Info) }
+func (m *mockProvider) GetName() string                         { return "mock" }
+func (m *mockProvider) GetType() string                         { return "mock" }
 func (m *mockProvider) GetCounterCompletion() *expvar.Int       { return expvar.NewInt("mock_completion") }
 func (m *mockProvider) GetCounterCompletionFailed() *expvar.Int { return expvar.NewInt("mock_failed") }
 
@@ -48,6 +48,7 @@ func TestCallLLM_RespectsParentContext(t *testing.T) {
 					return "", ctx.Err()
 				default:
 					t.Error("expected context to be cancelled, but it was not")
+
 					return "should not reach", nil
 				}
 			},
@@ -73,6 +74,7 @@ func TestCallLLM_RespectsParentContext(t *testing.T) {
 				if !ok || val != expectedVal {
 					t.Errorf("expected context value %q, got %q (ok=%v)", expectedVal, val, ok)
 				}
+
 				return "commit message", nil
 			},
 		}
@@ -97,6 +99,7 @@ func TestCallLLM_RespectsParentContext(t *testing.T) {
 				deadline, ok := ctx.Deadline()
 				if !ok {
 					t.Error("expected context to have a deadline")
+
 					return "", nil
 				}
 

--- a/internal/tui/choice_test.go
+++ b/internal/tui/choice_test.go
@@ -72,28 +72,44 @@ func TestChoiceModel_Update_Navigation(t *testing.T) {
 
 	// Move down.
 	model, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
-	cm := model.(ChoiceModel)
+	cm, ok := model.(ChoiceModel)
+	if !ok {
+		t.Fatal("expected ChoiceModel type")
+	}
+
 	if cm.cursor != 1 {
 		t.Errorf("expected cursor=1 after 'j', got %d", cm.cursor)
 	}
 
 	// Move down again.
 	model, _ = cm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
-	cm = model.(ChoiceModel)
+	cm, ok = model.(ChoiceModel)
+	if !ok {
+		t.Fatal("expected ChoiceModel type")
+	}
+
 	if cm.cursor != 2 {
 		t.Errorf("expected cursor=2, got %d", cm.cursor)
 	}
 
 	// Wrap around at bottom.
 	model, _ = cm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
-	cm = model.(ChoiceModel)
+	cm, ok = model.(ChoiceModel)
+	if !ok {
+		t.Fatal("expected ChoiceModel type")
+	}
+
 	if cm.cursor != 0 {
 		t.Errorf("expected cursor=0 (wrap), got %d", cm.cursor)
 	}
 
 	// Move up wraps to bottom.
 	model, _ = cm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
-	cm = model.(ChoiceModel)
+	cm, ok = model.(ChoiceModel)
+	if !ok {
+		t.Fatal("expected ChoiceModel type")
+	}
+
 	if cm.cursor != 2 {
 		t.Errorf("expected cursor=2 (wrap up), got %d", cm.cursor)
 	}


### PR DESCRIPTION
## What

Migrate committer to the sypl **v2** module (`github.com/thalesfsp/sypl/v2 v2.0.0`).

## Why

sypl v2 isolates ElasticSearch into a separate `es/` submodule and adopts conventional level ordering. This repo's usage is trivial:

- **No ElasticSearch outputs**, so the `es/v2` submodule is not needed.
- **No removed-API call sites** (`SetName`/`GetProcessor`/`SetContent`/`SetLevel`/`AnyMaxLevel`/`SetBuiltinLogger`/`FromInt`/etc.).
- The **Warn/Info reorder is inert** here — the two `NewDefault(..., level.Info)` sites only construct loggers; nothing asserts Warn-at-Info visibility.

## Changes

- `cmd/root.go`: sypl imports rewritten to the `/v2` module path.
- `go.mod` / `go.sum`: add `github.com/thalesfsp/sypl/v2 v2.0.0`; `go mod tidy`.

## Cross-version note

`github.com/thalesfsp/sypl` **v1.9.18 remains a direct (test-only) dependency**. The `internal/provider` test mock implements `inference`'s `provider.IProvider`, whose `GetLogger()` return type is bound to sypl **v1** until `inference` itself migrates. `internal/provider/provider_test.go` therefore keeps its v1 imports — migrating it would break interface satisfaction. This is expected, not a defect.

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test -race ./...` — all packages pass